### PR TITLE
Ab issue#21 Expo Image Picker Added

### DIFF
--- a/client/app.json
+++ b/client/app.json
@@ -9,6 +9,7 @@
     "packagerOpts": {
       "sourceExts": ["cjs"]
     },
+    "plugins": ["expo-image-picker"],
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native": "^6.0.12",
         "@react-navigation/native-stack": "^6.8.0",
         "expo": "~46.0.9",
+        "expo-image-picker": "~13.3.1",
         "expo-status-bar": "~1.4.0",
         "firebase": "^9.6.11",
         "react": "18.0.0",
@@ -9617,6 +9618,35 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-3.2.0.tgz",
+      "integrity": "sha512-LU3Q2prn64/HxdToDmxgMIRXS1ZvD9Q3iCxRVTZn1fPQNNDciIQFE5okaa74Ogx20DFHs90r6WoUd7w9Af1OGQ==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-13.3.1.tgz",
+      "integrity": "sha512-IY84uDu9uxetAup5yw0CIIujigl/lM3grwyfpeZFMKGmWHzmKamptjd/sG8K65xkb6tF9awmGMW0qglHQ9hakQ==",
+      "dependencies": {
+        "@expo/config-plugins": "~5.0.0",
+        "expo-image-loader": "~3.2.0",
+        "uuid": "7.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker/node_modules/uuid": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/expo-keep-awake": {
@@ -30680,6 +30710,29 @@
       "integrity": "sha512-2V4EcpmhNoppaLn+lPprZVS+3bmV9hxLPKttKh2u8ghjH/oX9bv3u4JVo77SYh0EfrWO4toqVyXn8pXH8GpbIg==",
       "requires": {
         "fontfaceobserver": "^2.1.0"
+      }
+    },
+    "expo-image-loader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-3.2.0.tgz",
+      "integrity": "sha512-LU3Q2prn64/HxdToDmxgMIRXS1ZvD9Q3iCxRVTZn1fPQNNDciIQFE5okaa74Ogx20DFHs90r6WoUd7w9Af1OGQ==",
+      "requires": {}
+    },
+    "expo-image-picker": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-13.3.1.tgz",
+      "integrity": "sha512-IY84uDu9uxetAup5yw0CIIujigl/lM3grwyfpeZFMKGmWHzmKamptjd/sG8K65xkb6tF9awmGMW0qglHQ9hakQ==",
+      "requires": {
+        "@expo/config-plugins": "~5.0.0",
+        "expo-image-loader": "~3.2.0",
+        "uuid": "7.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+        }
       }
     },
     "expo-keep-awake": {

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,8 @@
     "react-native-safe-area-context": "4.3.1",
     "react-native-screens": "~3.15.0",
     "react-native-web": "~0.18.7",
-    "tailwind-rn": "^4.2.0"
+    "tailwind-rn": "^4.2.0",
+    "expo-image-picker": "~13.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/client/screens/ProfilePage.js
+++ b/client/screens/ProfilePage.js
@@ -19,6 +19,7 @@ import {
   update,
   remove,
 } from "firebase/database";
+import * as ImagePicker from "expo-image-picker";
 
 const ProfilePage = (props) => {
   const currentUser = useAuth();

--- a/client/screens/ProfilePage.js
+++ b/client/screens/ProfilePage.js
@@ -5,6 +5,7 @@ import {
   TextInput,
   Image,
   ScrollView,
+  Button,
 } from "react-native";
 import React, { useState, useEffect } from "react";
 import styles from "./ProfilePageStyles";
@@ -30,6 +31,7 @@ const ProfilePage = (props) => {
   const [photoURL, setPhotoURL] = useState(
     "https://www.pngitem.com/pimgs/m/150-1503945_transparent-user-png-default-user-image-png-png.png"
   );
+  const [image, setImage] = useState(null);
 
   const [data, setData] = useState({});
 
@@ -38,6 +40,23 @@ const ProfilePage = (props) => {
 
   const userRef = ref(db, "users/" + props.userId);
   const newUserRef = push(userRef);
+
+  // Image Picker
+  const pickImage = async () => {
+    // No permissions request is necessary for launching the image library
+    let result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.All,
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 1,
+    });
+
+    console.log(result);
+
+    if (!result.cancelled) {
+      setImage(result.uri);
+    }
+  };
 
   useEffect(() => {
     return onValue(userRef, (snapshot) => {
@@ -97,12 +116,28 @@ const ProfilePage = (props) => {
           <Text style={styles.pageTitle}>Profile</Text>
         </View>
         <View style={styles.topUserInfo}>
-          {/* <Image style={styles.topUserInfoImage} /> */}
+          <View
+            style={{ flex: 1, alignItems: "center", justifyContent: "center" }}
+          >
+            <Button
+              title="Pick an image from camera roll"
+              onPress={pickImage}
+            />
+            {image && (
+              <Image
+                source={{ uri: image }}
+                style={{ width: 200, height: 200 }}
+              />
+            )}
+          </View>
+
+          {/* input, button, and img cause errors on mobile devices and emulator, Works on web not mobile. */}
+          {/* <Image style={styles.topUserInfoImage} />
           <input type="file" onChange={handleChange} />
           <button disabled={loading || !photo} onClick={handleClick}>
             <Text>Upload</Text>
           </button>
-          <img src={photoURL} alt="avatar" />
+          <img src={photoURL} alt="avatar" /> */}
           <Text style={styles.topUserInfoName}>BOB</Text>
           <Text style={styles.topUserInfoLocation}>Fresno,CA</Text>
         </View>


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Installed Expo Image Picker to allow upload and access to mobile camera rolls 


## Purpose
Added expo image picker to allow access to camera roll from mobile phones and emulators. Previously only worked on web.

## Approach
Previously, uploading images to profile page only worked on web and not on mobile devices. The code added helps us allow access to mobile phone camera rolls as intended. 

## Testing Steps
Please run emulator or using qr code to run expo on phone to test if it is allowing access to camera roll with no errors. 

## Learning
https://docs.expo.dev/versions/latest/sdk/imagepicker/
https://github.com/expo/examples/blob/master/with-firebase-storage-upload/App.js
