### PR TITLE
created a fetch image function inside a useEffect to display profile image

### DIFF
--- a/client/screens/ProfilePage.js
+++ b/client/screens/ProfilePage.js
@@ -41,6 +41,7 @@ const ProfilePage = (props) => {
     "https://www.pngitem.com/pimgs/m/150-1503945_transparent-user-png-default-user-image-png-png.png"
   );
   const [image, setImage] = useState(null);
+  // const [imageUrl, setImageUrl] = useState(undefined);
   const [uploading, setUploading] = useState(false);
 
   const [data, setData] = useState({});
@@ -103,11 +104,22 @@ const ProfilePage = (props) => {
     });
 
     // const fileRef = sRef(getStorage(), uuid.v4());
-    const userImageRef = sRef(storage, `users/` + props.userId, uuid.v4());
+    const userImageRef = sRef(storage, `users/${props.userId}`, uuid.v4());
     const result = await uploadBytes(userImageRef, blob);
 
     return await getDownloadURL(userImageRef);
   }
+
+  useEffect(() => {
+    const fetchImage = async () => {
+      const storage = getStorage();
+      const reference = sRef(storage, `users/${props.userId}`);
+      await getDownloadURL(reference).then((url) => {
+        setImage(url);
+      });
+    };
+    fetchImage();
+  }, []);
 
   useEffect(() => {
     return onValue(userRef, (snapshot) => {


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Profile image now fetches and displays previously uploaded images even when refreshed, no longer disappears 


## Purpose
Created a fetchImage function inside a useEffect to look through the database to see if an image was previously uploaded by user. If there is one, it will fetch and display as the users profile images

## Approach
This fixes the issue where if a user reloaded or left the profile page, the image would be gone and not shown on screen.


## Testing Steps
Upload image to firebase from profile page and refresh and logout/login to make sure image still shows 

