### PR TITLE
Fixed bug showing previous user profile image on initial login

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -67,8 +67,9 @@ function App() {
           <Tab.Screen
             name="LoginPage"
             options={{
-
-              tabBarIcon:() => (<Icon name='envelope' type='font-awesome' color='#444'/>),
+              tabBarIcon: () => (
+                <Icon name="envelope" type="font-awesome" color="#444" />
+              ),
 
               tabBarStyle: { display: "none" },
               headerShown: false,
@@ -78,24 +79,26 @@ function App() {
               <LoginPage {...props} userAuth={userAuth} userId={userId} />
             )}
           </Tab.Screen>
-            <Tab.Screen
-              name="HomePage"
-              options={{
-              
-                tabBarIcon:() => (<Icon name='home' type='font-awesome' color='#444'/>),
-  
-                headerShown: false,
-              }}
-            >
-              {(props) => (
-                <HomePage {...props} userAuth={userAuth} userId={userId} />
-              )}
-            </Tab.Screen>
+          <Tab.Screen
+            name="HomePage"
+            options={{
+              tabBarIcon: () => (
+                <Icon name="home" type="font-awesome" color="#444" />
+              ),
+
+              headerShown: false,
+            }}
+          >
+            {(props) => (
+              <HomePage {...props} userAuth={userAuth} userId={userId} />
+            )}
+          </Tab.Screen>
           <Tab.Screen
             name="ProfilePage"
             options={{
-
-              tabBarIcon:() => (<Icon name='user' type='font-awesome' color='#444'/>),
+              tabBarIcon: () => (
+                <Icon name="user" type="font-awesome" color="#444" />
+              ),
 
               headerShown: false,
             }}

--- a/client/screens/ProfilePage.js
+++ b/client/screens/ProfilePage.js
@@ -119,7 +119,7 @@ const ProfilePage = (props) => {
         const reference = sRef(storage, `users/${props.userId}`);
         await getDownloadURL(reference).then((url) => {
           setImage(url);
-          console.log(url);
+          editProfileImage(url);
         });
       };
 
@@ -137,7 +137,7 @@ const ProfilePage = (props) => {
 
         setData(result);
       } else {
-        set(newUserRef, { username: "", bio: "" });
+        set(newUserRef, { username: "", bio: "", imageUrl: "" });
         setData({});
       }
     });
@@ -153,10 +153,13 @@ const ProfilePage = (props) => {
     setToggleEdit(!toggleEdit);
   };
 
+  const editProfileImage = (newImage) => {
+    update(userRef, { imageUrl: newImage });
+  };
+
   const signOut = () => {
     props.userAuth.signOut();
     setImage(null);
-    console.log(image);
   };
 
   return (

--- a/client/screens/ProfilePage.js
+++ b/client/screens/ProfilePage.js
@@ -111,15 +111,21 @@ const ProfilePage = (props) => {
   }
 
   useEffect(() => {
-    const fetchImage = async () => {
-      const storage = getStorage();
-      const reference = sRef(storage, `users/${props.userId}`);
-      await getDownloadURL(reference).then((url) => {
-        setImage(url);
-      });
-    };
-    fetchImage();
-  }, []);
+    if (props.userId === "") {
+      props.navigation.navigate("LoginPage");
+    } else {
+      const fetchImage = async () => {
+        const storage = getStorage();
+        const reference = sRef(storage, `users/${props.userId}`);
+        await getDownloadURL(reference).then((url) => {
+          setImage(url);
+          console.log(url);
+        });
+      };
+
+      fetchImage();
+    }
+  }, [props.userId]);
 
   useEffect(() => {
     return onValue(userRef, (snapshot) => {
@@ -136,6 +142,7 @@ const ProfilePage = (props) => {
       }
     });
   }, []);
+
   const editUsername = (newUsername) => {
     update(userRef, { username: newUsername });
     setToggleEdit(!toggleEdit);
@@ -148,11 +155,9 @@ const ProfilePage = (props) => {
 
   const signOut = () => {
     props.userAuth.signOut();
+    setImage(null);
+    console.log(image);
   };
-
-  useEffect(() => {
-    if (props.userId === "") props.navigation.navigate("LoginPage");
-  }, [props.userId]);
 
   return (
     <ScrollView style={styles.container}>


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Fixed issue where after logging in to a different account, the previously logged in user's image would show and not current user profile image. No need to refresh to show current user image anymore

## Purpose
Emptied image state on logout and added userId and dependency on useEffect to fetch current userId's profile images

## Approach
No longer need to refresh after logging in a different account to fetch new user profile image



_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #21 
