### PR TITLE
Ab issue#50 match functionality logic added

### DIFF
--- a/client/screens/HomePage.js
+++ b/client/screens/HomePage.js
@@ -11,7 +11,13 @@ import { useIsFocused } from "@react-navigation/native";
 import { useTailwind } from "tailwind-rn";
 import { Entypo } from "@expo/vector-icons";
 import Swiper from "react-native-deck-swiper";
-import { doc, onSnapshot, collection } from "firebase/firestore";
+import {
+  doc,
+  setDoc,
+  onSnapshot,
+  collection,
+  getDocs,
+} from "firebase/firestore";
 import { getFirestore } from "firebase/firestore";
 import app from "../Firebase/firebase";
 
@@ -27,6 +33,11 @@ const Home = (props) => {
 
   useEffect(() => {
     const fetchUsers = async () => {
+      const passes = await getDocs(collection(db, "users", props.userId)).then(
+        (snapshot) => snapshot.docs.map((doc) => doc.id)
+      );
+      console.log(passes);
+
       onSnapshot(collection(db, "users"), (snapshot) => {
         setUsersList(
           snapshot.docs
@@ -39,9 +50,26 @@ const Home = (props) => {
       });
     };
 
-    console.log(usersList);
     fetchUsers();
   }, []);
+
+  const swipeLeft = (cardIndex) => {
+    if (!usersList[cardIndex]) return;
+
+    const userSwiped = usersList[cardIndex];
+    // console.log(`You swiped PASS on ${userSwiped.username}`);
+
+    setDoc(doc(db, "users", props.userId, "passed", userSwiped.id), userSwiped);
+  };
+
+  const swipeRight = (cardIndex) => {
+    if (!usersList[cardIndex]) return;
+
+    const userSwiped = usersList[cardIndex];
+    // console.log(`You swiped MATCH on ${userSwiped.username}`);
+
+    setDoc(doc(db, "users", props.userId, "swipes", userSwiped.id), userSwiped);
+  };
 
   return (
     <SafeAreaView style={tw("flex-1")}>
@@ -60,11 +88,13 @@ const Home = (props) => {
             stackSize={5}
             cardIndex={0}
             animateCardOpacity
-            onSwipedLeft={() => {
+            onSwipedLeft={(cardIndex) => {
               console.log("Swipe PASSED");
+              swipeLeft(cardIndex);
             }}
-            onSwipedRight={() => {
+            onSwipedRight={(cardIndex) => {
               console.log("Swipe MATCH");
+              swipeRight(cardIndex);
             }}
             overlayLabels={{
               left: {

--- a/client/screens/HomePage.js
+++ b/client/screens/HomePage.js
@@ -17,6 +17,8 @@ import {
   onSnapshot,
   collection,
   getDocs,
+  getDoc,
+  DocumentSnapshot,
 } from "firebase/firestore";
 import { getFirestore } from "firebase/firestore";
 import app from "../Firebase/firebase";
@@ -33,10 +35,10 @@ const Home = (props) => {
 
   useEffect(() => {
     const fetchUsers = async () => {
-      const passes = await getDocs(collection(db, "users", props.userId)).then(
-        (snapshot) => snapshot.docs.map((doc) => doc.id)
-      );
-      console.log(passes);
+      // const passes = await getDocs(collection(db, "users", props.userId)).then(
+      //   (snapshot) => snapshot.docs.map((doc) => doc.id)
+      // );
+      // console.log(passes);
 
       onSnapshot(collection(db, "users"), (snapshot) => {
         setUsersList(
@@ -62,13 +64,32 @@ const Home = (props) => {
     setDoc(doc(db, "users", props.userId, "passed", userSwiped.id), userSwiped);
   };
 
-  const swipeRight = (cardIndex) => {
+  const swipeRight = async (cardIndex) => {
     if (!usersList[cardIndex]) return;
 
     const userSwiped = usersList[cardIndex];
-    // console.log(`You swiped MATCH on ${userSwiped.username}`);
+    const loggedInProfile = await (
+      await getDoc(doc(db, "users", props.userId))
+    ).data();
+    console.log(loggedInProfile);
 
-    setDoc(doc(db, "users", props.userId, "swipes", userSwiped.id), userSwiped);
+    getDoc(doc(db, "users", userSwiped.id, "swipes", props.userId)).then(
+      (DocumentSnapshot) => {
+        if (DocumentSnapshot.exists()) {
+          setDoc(
+            doc(db, "users", props.userId, "swipes", userSwiped.id),
+            userSwiped
+          );
+          console.log(`You've matched with ${userSwiped.username}`);
+        } else {
+          console.log(`You swiped on ${userSwiped.username}`);
+          setDoc(
+            doc(db, "users", props.userId, "swipes", userSwiped.id),
+            userSwiped
+          );
+        }
+      }
+    );
   };
 
   return (

--- a/client/screens/HomePage.js
+++ b/client/screens/HomePage.js
@@ -38,10 +38,6 @@ const Home = (props) => {
 
   useEffect(() => {
     const fetchUsers = async () => {
-      // const passes = await getDocs(collection(db, "users", props.userId)).then(
-      //   (snapshot) => snapshot.docs.map((doc) => doc.id)
-      // );
-      // console.log(passes);
 
       onSnapshot(collection(db, "users"), (snapshot) => {
         setUsersList(

--- a/client/screens/MatchPage.js
+++ b/client/screens/MatchPage.js
@@ -1,13 +1,21 @@
-import { Text, View } from 'react-native'
-import React from 'react'
+import { Text, View } from "react-native";
+import { useRoute } from "@react-navigation/native";
+import React from "react";
 
 const MatchPage = () => {
+  const { params } = useRoute();
+
+  const { loggedInProfile, userSwiped } = params;
+
   return (
     <View>
       <Text>MatchPage</Text>
+      <Text>
+        {loggedInProfile.username} and {userSwiped.username} have matched. Send
+        your first message to link up in game!
+      </Text>
     </View>
-  )
-}
+  );
+};
 
-export default MatchPage
-
+export default MatchPage;


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added the ability to match with users if there was intent from BOTH users, meaning if both users swiped right, they are now redirected to the "match page with a message displaying both usernames and saying they've matched.


## Purpose
_Describe the problem or feature in addition to a link to the issues._
Added logic to the swipe right function. If the logged in user swipes right on a profile, it will check swiped users' swiped collection to see if they have already swiped match on you first. 

If they have , we create a new collection and generate a new matchId that is the concatenation of both userIds and store both users inside.

If they haven't, the user has to wait until the other user swipes right on them to proceed


## Testing Steps
_How do the users test this change?_
Create 2 accounts and try to swipe right on each other from both accounts. When logged in to the second account, after you swipe right, you should be redirected to the match page screen with a message displaying both accounts correct usernames
