### PR TITLE
displaying users retrieved from matches collection and displaying on match page

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -8,6 +8,7 @@ import LoginPage from "./screens/LoginPage";
 import ProfilePage from "./screens/ProfilePage";
 import HomePage from "./screens/HomePage";
 import MatchPage from "./screens/MatchPage";
+import ChatRoom from "./screens/ChatRoom";
 import firebase from "./Firebase/firebase";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
@@ -39,7 +40,7 @@ function App() {
   return (
     <TailwindProvider utilities={utilities}>
       <NavigationContainer>
-        <Tab.Navigator initialRouteName="HomePage" style={styles.container}>
+        <Tab.Navigator initialRouteName="MatchPage" style={styles.container}>
           <Tab.Screen
             name="LandingPage"
             options={{
@@ -107,6 +108,20 @@ function App() {
           >
             {(props) => (
               <ProfilePage {...props} userAuth={userAuth} userId={userId} />
+            )}
+          </Tab.Screen>
+          <Tab.Screen
+            name="ChatRoom"
+            options={{
+              tabBarIcon: () => (
+                <Icon name="user" type="font-awesome" color="#444" />
+              ),
+
+              headerShown: false,
+            }}
+          >
+            {(props) => (
+              <ChatRoom {...props} userAuth={userAuth} userId={userId} />
             )}
           </Tab.Screen>
         </Tab.Navigator>

--- a/client/components/MessageRow.js
+++ b/client/components/MessageRow.js
@@ -1,0 +1,40 @@
+import { View, Text, Image, StyleSheet, TouchableOpacity } from "react-native";
+import React, { useState, useEffect } from "react";
+
+const MessageRow = ({ matchDetails, userId, props }) => {
+  const [matchedUserInfo, setMatchedUserInfo] = useState(null);
+
+  const getMatchedUserInfo = (users, userId) => {
+    const newUsers = { ...users };
+
+    delete newUsers[userId];
+
+    const [id, user] = Object.entries(newUsers).flat();
+    return { id, ...user };
+  };
+
+  useEffect(() => {
+    setMatchedUserInfo(getMatchedUserInfo(matchDetails.users, userId));
+  }, [matchDetails, userId]);
+
+  return (
+    <View>
+      <TouchableOpacity onPress={() => props.navigation.navigate("ChatRoom")}>
+        <Image
+          style={styles.matchedUserImage}
+          source={{ uri: matchedUserInfo?.image }}
+        />
+        <Text>{matchedUserInfo?.username}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default MessageRow;
+
+const styles = StyleSheet.create({
+  matchedUserImage: {
+    height: 100,
+    width: 100,
+  },
+});

--- a/client/screens/ChatRoom.js
+++ b/client/screens/ChatRoom.js
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import React from "react";
+
+const ChatRoom = (props) => {
+  return (
+    <View>
+      <Text>Hello from chat room!</Text>
+    </View>
+  );
+};
+
+export default ChatRoom;

--- a/client/screens/MatchPage.js
+++ b/client/screens/MatchPage.js
@@ -1,21 +1,46 @@
-import { Text, View } from "react-native";
+import { FlatList, Text, View } from "react-native";
 import { useRoute } from "@react-navigation/native";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { onSnapshot } from "firebase/firestore";
+import { collection, doc, query, where } from "@firebase/firestore";
+import { getFirestore } from "firebase/firestore";
+import app from "../Firebase/firebase";
+import { ListItem } from "react-native-elements";
+import MessageRow from "../components/MessageRow";
 
-const MatchPage = () => {
-  const { params } = useRoute();
+const MatchPage = (props) => {
+  const [matches, setMatches] = useState([]);
 
-  const { loggedInProfile, userSwiped } = params;
+  const db = getFirestore(app);
 
-  return (
+  useEffect(() => {
+    onSnapshot(
+      query(
+        collection(db, "matches"),
+        where("usersMatched", "array-contains", props.userId)
+      ),
+      (snapshot) =>
+        setMatches(
+          snapshot.docs.map((doc) => ({
+            id: doc.id,
+            ...doc.data(),
+          }))
+        )
+    );
+  }, [props.userId]);
+
+  return matches.length > 0 ? (
+    <FlatList
+      data={matches}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => (
+        <MessageRow matchDetails={item} userId={props.userId} props={props} />
+      )}
+    />
+  ) : (
     <View>
-      <Text>MatchPage</Text>
-      <Text>
-        {loggedInProfile.username} and {userSwiped.username} have matched. Send
-        your first message to link up in game!
-      </Text>
+      <Text>No matches at the moment.. Keep searching!</Text>
     </View>
   );
 };
-
 export default MatchPage;

--- a/client/screens/ProfilePage.js
+++ b/client/screens/ProfilePage.js
@@ -126,9 +126,7 @@ const ProfilePage = (props) => {
   useEffect(() => {
     const fetchUserInfo = () => {
       onSnapshot(doc(db, `users/${props.userId}`), (snapshot) => {
-        console.log(snapshot.data());
         setData(snapshot.data());
-        console.log(data);
       });
     };
 


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. queried and displayed matched users from "matches" collection in firestore to display all of the users the currently logged in user has matched with.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
queried through our collection "matches" to only return the ones where we are in. Then I added a Flatlist to pass that data through and it returns a custom component which contains the info for our other matched users.

## Approach
_How does this change address the problem?_
Users now have access to view all of their matches



_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #50 
